### PR TITLE
[HEENDY-65-kakao-login] 프록시 세팅 및 카카오 로그인 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.6.7",
     "bootstrap": "^5.3.2",
     "dotenv": "^16.4.5",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -17,6 +18,7 @@
     "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
+    "react-kakao-login": "^2.1.1",
     "react-qr-scanner": "^1.0.0-alpha.11",
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.22.0",
@@ -70,5 +72,6 @@
     "eslint-plugin-react": "^7.33.2",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.1"
-  }
+  },
+  "proxy": "http://localhost:8080"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@
  */
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Login from './pages/Login/Login';
+import KakaoCallback from './pages/Login/KakaoCallback';
 import MainPage from './pages/MainPage/Mainpage';
 import LocationPage from './pages/Location/LocationPage';
 import QRScannerPage from './pages/QRScannerPage/QRScannerPage';
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
     path: '/',
     children: [
       { index: true, element: <Login /> },
+      { path: 'login', element: <KakaoCallback />},
       { path: 'main', element: <MainPage /> },
       { path: 'location', element: <LocationPage /> },
       { path: 'login', element: <Login /> },

--- a/src/apis/api.js
+++ b/src/apis/api.js
@@ -6,9 +6,6 @@
  * @desc api 기본 설정
  */
 import axios from 'axios';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 const API_AUTH_TOKEN = process.env.REACT_APP_API_AUTH_TOKEN;

--- a/src/apis/request.js
+++ b/src/apis/request.js
@@ -43,3 +43,24 @@ export const createReviewForStore = async (storeId, reviewReqDto) => {
     throw error;
   }
 };
+
+/**
+ * @author 엄상은
+ * @email sangeun.e.9@gmail.com
+ * @create date 2024-02-26 19:41:08
+ * @modify date 2024-02-26 19:41:08
+ * @desc 로그인 api 연결
+ */
+
+// 카카오 로그인
+export const login = async (accessToken) => {
+  try {
+    const response = await api.post('/api/v1/auth/login', {
+      "loginToken": accessToken,
+      "oauthType": "KAKAO"
+    });
+    return response.data.accessToken;
+  } catch (error) {
+    console.error(`Error: ${error}`);
+  }
+}

--- a/src/apis/requests/kakaoRequest.js
+++ b/src/apis/requests/kakaoRequest.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+/**
+ * @author 엄상은
+ * @email sangeun.e.9@gmail.com
+ * @create date 2024-02-26 19:41:08
+ * @modify date 2024-02-26 19:41:08
+ * @desc 카카오에서 인가코드로 accessToken 받기
+ */
+export const getAccessToken = async code => {
+    const params = new URLSearchParams();
+    params.append("grant_type", "authorization_code");
+    params.append("client_id", process.env.REACT_APP_KAKAO_CLIENT_ID);
+    params.append("redirect_uri", process.env.REACT_APP_KAKAO_REDIRECT_URI);
+    params.append("code", code);
+  
+    try {
+        const response = await axios({
+            method: 'post',
+            url: 'https://kauth.kakao.com/oauth/token',
+            headers: {
+                'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+            },
+            data: params
+        });
+        return response.data.access_token;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+    }
+}

--- a/src/pages/Login/KakaoCallback.js
+++ b/src/pages/Login/KakaoCallback.js
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAccessToken } from '../../apis/requests/kakaoRequest';
+import { login } from '../../apis/request';
+
+/**
+ * @author 엄상은
+ * @email sangeun.e.9@gmail.com
+ * @create date 2024-02-26 19:41:08
+ * @modify date 2024-02-26 19:41:08
+ * @desc 로그인 전체 로직
+ */
+
+function KakaoCallback() {
+    const navigate = useNavigate();
+    useEffect(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const code = urlParams.get('code');
+        console.log("1. 카카오로부터 얻은 code:" + code);
+
+        // 비동기 작업 처리
+        const processLogin = async () => {
+            try {
+                const accessToken = await getAccessToken(code);
+                console.log("2. 카카오 accessToken:" + accessToken);
+                const jwt = await login(accessToken);
+                console.log("3. 자체 jwt 토큰:" + jwt);
+                // spring에서 발급된 jwt localStorage 저장
+                localStorage.setItem("accessToken", jwt);
+                // 메인 페이지로 이동
+                navigate('/main');
+            } catch (error) {
+                console.error("로그인 처리 실패", error);
+            }
+        };
+        processLogin();
+    }, [navigate]);
+}
+
+export default KakaoCallback;

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -17,7 +17,7 @@
 import loginImage from 'assets/images/onboarding_icon.png';
 
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+// import { useNavigate } from 'react-router-dom';
 // import { firebaseConfig } from './config';
 
 // // Firebase 앱 초기화
@@ -83,7 +83,7 @@ import { useNavigate } from 'react-router-dom';
 // }
 
 function LoginScreen() {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   // 사용자가 로그인 화면에 진입했을 때 알림 권한을 요청하고 FCM 토큰을 등록합니다.
   // React.useEffect(() => {
@@ -91,7 +91,8 @@ function LoginScreen() {
   // }, []);
 
   const handleLogin = () => {
-    navigate('/main');
+    const KAKAO_AUTH_URI = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&scope=account_email&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECT_URI}`
+    window.location.href = KAKAO_AUTH_URI;
   };
 
   return (

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,22 @@
+/**
+ * @author 엄상은
+ * @email sangeun.e.9@gmail.com
+ * @create date 2024-02-26 19:41:08
+ * @modify date 2024-02-26 19:41:08
+ * @desc 프록시 세팅
+ */
+
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function (app) {
+  // process.env.REACT_APP_BACK_SERVER_URL
+  const target = "http://localhost:8080";
+
+  app.use(
+    "/api/v1",
+    createProxyMiddleware({
+      target,
+      changeOrigin: true,
+    })
+  );
+};

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -9,8 +9,8 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
-  // process.env.REACT_APP_BACK_SERVER_URL
-  const target = "http://localhost:8080";
+  
+  const target = process.env.REACT_APP_API_BASE_URL;
 
   app.use(
     "/api/v1",


### PR DESCRIPTION
## 구현 사항
- 프록시 세팅
- 카카오 로그인 API 연결

## 프론트 환경변수 세팅 (.env)
- [FE/BE 환경 변수](https://sooyoung.atlassian.net/wiki/x/KwAd)

## 참고 사항
- 카카오 서버 400 요청은 비동기 처리가 제대로 안 되어서 그런 거였습니다..^^
- 카카오 로그인은 프론트에서 카카오로부터 code를 얻고, 프론트에서 카카오로 accessToken 직접 요청, 이렇게 얻은 accessToken을 서버로 보내서 서버에서 accessToken으로 자체 JWT 토큰 발급. 이걸 받아와서 localStorage에 저장합니다 (안드로이드 방식)
- **앞으로 localStorage에서 꺼내서, 통신 시 헤더로 보내주도록 하면 됩니다**

## 스크린샷
<img width="913" alt="image" src="https://github.com/hyundai-fruitfruit/frontend/assets/63828057/bf5b4367-2c91-4ae2-b978-daed1742594f">